### PR TITLE
LKE-9778 Revert "LKE-9778 fix (plugins) Plugin Manager: Tab Labels are not correctly aligned on z-axis"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@linkurious/rest-client": "3.1.14",
         "@types/express": "4.17.3",
         "@types/express-fileupload": "1.4.1",
-        "@types/node": "16.18.11",
+        "@types/node": "^16.18.11",
         "@types/superagent": "4.1.15",
         "@types/tar": "6.1.3",
         "@typescript-eslint/eslint-plugin": "5.48.1",

--- a/public/main.css
+++ b/public/main.css
@@ -88,7 +88,6 @@ body {
   border-top-right-radius: 10px;
   border-bottom-left-radius: 10px;
   border-bottom-right-radius: 10px;
-  z-index: 1;
 }
 
 .tab-switch:checked+.tab-label {


### PR DESCRIPTION
Reverts Linkurious/lke-plugin-plugin-manager#21

Issue is not about z-index but tabindex, this "bad behavior ignoring keyboard tab navigation" is triggered by `<label>` pointing to disabled (by display=none) `<input type=radio />` thus the browser is correctly disabling element's natural focus grab navigation capabilities. i think correct fix should be rewrite tabs with proper html elements ( `<a> `probably ?) cc @justinmarsan 